### PR TITLE
refactor: add company logo display in MSME component

### DIFF
--- a/src/components/guest/MSMEList.tsx
+++ b/src/components/guest/MSMEList.tsx
@@ -23,7 +23,7 @@ export default function MSMEList({ msmes }: MSMEListProps) {
                   <CardHeader className="relative p-0">
                     <div className="absolute inset-0 z-10 bg-gradient-to-t from-black/20 to-transparent" />
                     <Image
-                      src={`${msme.productGallery?.[0] ?? "/placeholder.png"}`}
+                      src={`${msme.productGallery?.[0] ?? "/placeholder-image.png"}`}
                       alt={msme.companyName}
                       width={400}
                       height={240}
@@ -31,7 +31,7 @@ export default function MSMEList({ msmes }: MSMEListProps) {
                     />
                     {msme.companyLogo && (
                       <Image
-                        src={`${msme.companyLogo ?? "/placeholder.png"}`}
+                        src={`${msme.companyLogo ?? "/no_image_placeholder.jpg"}`}
                         alt={msme.companyName}
                         width={56}
                         height={56}

--- a/src/components/guest/MSMEList.tsx
+++ b/src/components/guest/MSMEList.tsx
@@ -29,6 +29,15 @@ export default function MSMEList({ msmes }: MSMEListProps) {
                       height={240}
                       className="h-56 w-full object-cover transition-transform duration-300 group-hover:scale-105"
                     />
+                    {msme.companyLogo && (
+                      <Image
+                        src={`${msme.companyLogo ?? "/placeholder.png"}`}
+                        alt={msme.companyName}
+                        width={56}
+                        height={56}
+                        className="absolute bottom-4 right-4 z-20 h-14 w-14 rounded-full border-2 border-white object-cover shadow-md"
+                      />
+                    )}
                     <Badge className="absolute bottom-4 left-4 z-20 bg-amber-600/90 hover:bg-amber-600">
                       {msme.sectorName}
                     </Badge>

--- a/src/components/modals/AddMSMEModal.tsx
+++ b/src/components/modals/AddMSMEModal.tsx
@@ -280,27 +280,23 @@ export default function AddMSMEModal({ isOpen, onClose }: AddMSMEModalProps) {
                         width={64}
                         height={64}
                       />
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        size="icon"
-                        className="absolute -right-2 -top-2 h-6 w-6 rounded-full"
-                        onClick={() => {
-                          setCompanyLogo("");
-                          setLogoUrl("");
-                          setLogoFile(null);
-                        }}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
                     </div>
                   )}
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => setIsCropModalOpen(true)}
+                    onClick={() => {
+                      if (logoUrl) {
+                        setCompanyLogo("");
+                        setLogoUrl("");
+                        setLogoFile(null);
+                        setIsCropModalOpen(false);
+                      } else {
+                        setIsCropModalOpen(true);
+                      }
+                    }}
                   >
-                    {companyLogo ? "Change Logo" : "Upload Logo"}
+                    {logoUrl ? "Change Logo" : "Upload Logo"}
                   </Button>
                 </div>
               </div>

--- a/src/components/modals/AddMSMEModal.tsx
+++ b/src/components/modals/AddMSMEModal.tsx
@@ -60,6 +60,7 @@ export default function AddMSMEModal({ isOpen, onClose }: AddMSMEModalProps) {
   const [marker, setMarker] = useState<{ lat: number; lng: number } | null>(
     null,
   );
+  const [isLogoUploading, setIsLogoUploading] = useState(false);
 
   // Generate years for select (from 1900 to current year)
   const currentYear = new Date().getFullYear();
@@ -102,6 +103,7 @@ export default function AddMSMEModal({ isOpen, onClose }: AddMSMEModalProps) {
   };
 
   const handleLogoUpload = async (croppedFile: File) => {
+    setIsLogoUploading(true);
     try {
       const fileName = `logo-${Date.now()}`;
       const url = await uploadImage(croppedFile, fileName);
@@ -110,6 +112,8 @@ export default function AddMSMEModal({ isOpen, onClose }: AddMSMEModalProps) {
       setLogoFile(croppedFile);
     } catch {
       toast.error("Failed to upload logo");
+    } finally {
+      setIsLogoUploading(false);
     }
   };
 
@@ -290,13 +294,23 @@ export default function AddMSMEModal({ isOpen, onClose }: AddMSMEModalProps) {
                         setCompanyLogo("");
                         setLogoUrl("");
                         setLogoFile(null);
-                        setIsCropModalOpen(false);
+                        setIsCropModalOpen(true);
                       } else {
                         setIsCropModalOpen(true);
                       }
                     }}
+                    disabled={isLogoUploading}
                   >
-                    {logoUrl ? "Change Logo" : "Upload Logo"}
+                    {isLogoUploading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Uploading...
+                      </>
+                    ) : logoUrl ? (
+                      "Change Logo"
+                    ) : (
+                      "Upload Logo"
+                    )}
                   </Button>
                 </div>
               </div>

--- a/src/components/modals/EditMSMEModal.tsx
+++ b/src/components/modals/EditMSMEModal.tsx
@@ -337,27 +337,23 @@ export default function EditMSMEModal({
                         width={64}
                         height={64}
                       />
-                      <Button
-                        type="button"
-                        variant="destructive"
-                        size="icon"
-                        className="absolute -right-2 -top-2 h-6 w-6 rounded-full"
-                        onClick={() => {
-                          setCompanyLogo("");
-                          setLogoUrl("");
-                          setLogoFile(null);
-                        }}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
                     </div>
                   )}
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={() => setIsCropModalOpen(true)}
+                    onClick={() => {
+                      if (logoUrl) {
+                        setCompanyLogo("");
+                        setLogoUrl("");
+                        setLogoFile(null);
+                        setIsCropModalOpen(false);
+                      } else {
+                        setIsCropModalOpen(true);
+                      }
+                    }}
                   >
-                    {companyLogo ? "Change Logo" : "Upload Logo"}
+                    {logoUrl ? "Change Logo" : "Upload Logo"}
                   </Button>
                 </div>
               </div>
@@ -638,7 +634,7 @@ export default function EditMSMEModal({
         isOpen={isCropModalOpen}
         onClose={() => setIsCropModalOpen(false)}
         onCropComplete={handleLogoUpload}
-        aspect={1} // Square aspect ratio
+        // aspect={1} // Square aspect ratio
       />
     </Dialog>
   );

--- a/src/components/modals/EditMSMEModal.tsx
+++ b/src/components/modals/EditMSMEModal.tsx
@@ -63,6 +63,7 @@ export default function EditMSMEModal({
     null,
   );
   const [isReplacingImages, setIsReplacingImages] = useState(false);
+  const [isLogoUploading, setIsLogoUploading] = useState(false);
 
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
@@ -151,6 +152,7 @@ export default function EditMSMEModal({
   };
 
   const handleLogoUpload = async (croppedFile: File) => {
+    setIsLogoUploading(true);
     try {
       // Delete old logo if it exists
       if (msme?.companyLogo) {
@@ -163,6 +165,8 @@ export default function EditMSMEModal({
       setLogoFile(croppedFile);
     } catch {
       toast.error("Failed to upload logo");
+    } finally {
+      setIsLogoUploading(false);
     }
   };
 
@@ -347,13 +351,23 @@ export default function EditMSMEModal({
                         setCompanyLogo("");
                         setLogoUrl("");
                         setLogoFile(null);
-                        setIsCropModalOpen(false);
+                        setIsCropModalOpen(true);
                       } else {
                         setIsCropModalOpen(true);
                       }
                     }}
+                    disabled={isLogoUploading}
                   >
-                    {logoUrl ? "Change Logo" : "Upload Logo"}
+                    {isLogoUploading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Uploading...
+                      </>
+                    ) : logoUrl ? (
+                      "Change Logo"
+                    ) : (
+                      "Upload Logo"
+                    )}
                   </Button>
                 </div>
               </div>

--- a/src/components/modals/ImageCropModal.tsx
+++ b/src/components/modals/ImageCropModal.tsx
@@ -188,7 +188,7 @@ export default function ImageCropModal({
                 tabIndex={_tabIndexFromProps}
                 className={`mt-1 flex cursor-pointer justify-center rounded-md border-2 border-dashed border-gray-300 px-6 pb-6 pt-5 hover:border-gray-400 dark:border-gray-600 dark:hover:border-gray-500 ${
                   _isDragActiveFromProps
-                    ? "border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-900/10"
+                    ? "border-emerald-500 bg-emerald-50 dark:border-emerald-400 dark:bg-emerald-900/10"
                     : ""
                 }`}
               >
@@ -209,7 +209,7 @@ export default function ImageCropModal({
                     />
                   </svg>
                   <div className="flex text-sm text-gray-600 dark:text-gray-400">
-                    <p className="relative rounded-md bg-white font-medium text-indigo-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 hover:text-indigo-500 dark:bg-transparent dark:text-indigo-400 dark:hover:text-indigo-300">
+                    <p className="relative rounded-md bg-white font-medium text-emerald-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-emerald-500 focus-within:ring-offset-2 hover:text-emerald-500 dark:bg-transparent dark:text-emerald-400 dark:hover:text-emerald-300">
                       <span>Upload a file</span>
                     </p>
                     <p className="pl-1">or drag and drop</p>


### PR DESCRIPTION
This pull request adds a feature to display a company logo on the MSME list if a logo is provided. The logo is styled as a circular image with a border and shadow, positioned in the bottom-right corner of the card.

### Enhancements to MSME list display:

* [`src/components/guest/MSMEList.tsx`](diffhunk://#diff-4349b39fa1716ba657a59570e33e24970b206c3122cb6b5e829c1487f439e8b3R32-R40): Added conditional rendering for `msme.companyLogo` to display a circular company logo with specific styling (e.g., border, shadow) at the bottom-right corner of the card. A placeholder image is used if no logo is provided.