### PR TITLE
style: update pagination and input colors to #996439 in Admin MSMEPage

### DIFF
--- a/src/app/admin/msme/[sectorName]/page.tsx
+++ b/src/app/admin/msme/[sectorName]/page.tsx
@@ -199,8 +199,8 @@ export default function MSMEPage({
             className={cn(
               "min-w-9 rounded-md",
               currentPage === pageNum
-                ? "bg-emerald-600 text-white hover:bg-emerald-600"
-                : "text-emerald-600 hover:bg-emerald-600",
+                ? "bg-[#996439] text-white hover:bg-[#996439]"
+                : "text-[#996439] hover:bg-[#996439]",
             )}
           >
             {pageNum}
@@ -225,14 +225,14 @@ export default function MSMEPage({
         }
         items.push(
           <PaginationItem key="end-ellipsis">
-            <PaginationEllipsis className="text-emerald-600" />
+            <PaginationEllipsis className="text-[#996439]" />
           </PaginationItem>,
         );
       } else if (currentPage >= totalPages - 2) {
         // Near end
         items.push(
           <PaginationItem key="start-ellipsis">
-            <PaginationEllipsis className="text-emerald-600" />
+            <PaginationEllipsis className="text-[#996439]" />
           </PaginationItem>,
         );
         for (let i = totalPages - 3; i < totalPages; i++) {
@@ -242,7 +242,7 @@ export default function MSMEPage({
         // In middle
         items.push(
           <PaginationItem key="start-ellipsis">
-            <PaginationEllipsis className="text-emerald-600" />
+            <PaginationEllipsis className="text-[#996439]" />
           </PaginationItem>,
         );
         for (let i = currentPage - 1; i <= currentPage + 1; i++) {
@@ -250,7 +250,7 @@ export default function MSMEPage({
         }
         items.push(
           <PaginationItem key="end-ellipsis">
-            <PaginationEllipsis className="text-emerald-600" />
+            <PaginationEllipsis className="text-[#996439]" />
           </PaginationItem>,
         );
       }
@@ -296,7 +296,7 @@ export default function MSMEPage({
                       setSearchTerm(e.target.value);
                       setCurrentPage(1);
                     }}
-                    className="pl-10 focus-visible:outline-emerald-600"
+                    className="pl-10 focus-visible:outline-[#996439]"
                   />
                   <Search
                     className="absolute left-3 top-2.5 text-gray-400"
@@ -468,7 +468,7 @@ export default function MSMEPage({
                             setCurrentPage((prev) => Math.max(prev - 1, 1))
                           }
                           className={cn(
-                            "rounded-md border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white",
+                            "rounded-md border-[#996439] text-[#996439] hover:bg-[#996439] hover:text-white",
                             currentPage === 1 &&
                               "pointer-events-none opacity-50",
                           )}
@@ -483,7 +483,7 @@ export default function MSMEPage({
                             )
                           }
                           className={cn(
-                            "rounded-md border-emerald-600 text-emerald-600 hover:bg-emerald-600 hover:text-white",
+                            "rounded-md border-[#996439] text-[#996439] hover:bg-[#996439] hover:text-white",
                             currentPage === totalPages &&
                               "pointer-events-none opacity-50",
                           )}


### PR DESCRIPTION
This pull request updates the color scheme of the pagination and search input components in the `MSMEPage` component to use a custom brown color (`#996439`) instead of the existing emerald green color (`emerald-600`). These changes ensure a consistent design across the page.

### Color Scheme Updates:

* Updated the active and hover states of pagination buttons to use `#996439` for background and text colors instead of `emerald-600`. (`src/app/admin/msme/[sectorName]/page.tsx`, [src/app/admin/msme/[sectorName]/page.tsxL202-R203](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L202-R203))
* Changed the color of `PaginationEllipsis` components to `#996439` for consistency with the new color scheme. (`src/app/admin/msme/[sectorName]/page.tsx`, [src/app/admin/msme/[sectorName]/page.tsxL228-R235](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L228-R235), [src/app/admin/msme/[sectorName]/page.tsxL245-R253](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L245-R253))
* Modified the focus outline color of the search input field to `#996439`. (`src/app/admin/msme/[sectorName]/page.tsx`, [src/app/admin/msme/[sectorName]/page.tsxL299-R299](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L299-R299))
* Adjusted the border, text, and hover colors of the "previous" and "next" pagination navigation buttons to use `#996439`. (`src/app/admin/msme/[sectorName]/page.tsx`, [src/app/admin/msme/[sectorName]/page.tsxL471-R471](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L471-R471), [src/app/admin/msme/[sectorName]/page.tsxL486-R486](diffhunk://#diff-9abeaa8a44c5b687f7016fb42d035c1bd62073ed6370465ed76af5684a519ef6L486-R486))